### PR TITLE
Aligned calendar icon + "News" link suffix changed

### DIFF
--- a/src/components/_featured.scss
+++ b/src/components/_featured.scss
@@ -39,7 +39,7 @@
 	}
 }
 
-.titlebox a[href$="/wiki/news"] {
+.titlebox a[href$="/news"] {
 	position: absolute;
 	display: block;
 	left: 20px;
@@ -138,7 +138,7 @@
 .side blockquote p:nth-child(2) {
     a {
         position: absolute;
-        top: 316px !important;
+        top: 314px !important;
         left: 490px !important;
         right: 0 !important;
         background: none;


### PR DESCRIPTION
Calendar icon in the header is now correctly aligned and the word "News" in the ticker will now link to the news section on the Paragon website. This will need to be updated if the website URL is changed.